### PR TITLE
Tilføj HTTP-autentificering

### DIFF
--- a/server/Api.Http/Api.Http.csproj
+++ b/server/Api.Http/Api.Http.csproj
@@ -11,11 +11,8 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.15" />
         <PackageReference Include="NSwag.AspNetCore" Version="14.3.0"/>
-    </ItemGroup>
-
-    <ItemGroup>
-        <Folder Include="Controllers\"/>
     </ItemGroup>
 
 </Project>

--- a/server/Api.Http/ApiStartup.cs
+++ b/server/Api.Http/ApiStartup.cs
@@ -1,22 +1,100 @@
-﻿using Microsoft.AspNetCore.Builder;
+﻿using Api.Http.Auth;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
+using NSwag;
+using NSwag.Generation.Processors.Security;
 
 namespace Api.Http;
 
 public static class ApiStartup
 {
+    private const string ApiTitle = "Brodbuddy API";
+    private const string ApiVersion = "v1";
+    private const string ApiDescription = "API til Brodbuddy";
+    
     public static IServiceCollection AddHttpApi(this IServiceCollection services)
     {
         services.AddControllers();
         services.AddEndpointsApiExplorer();
-        services.AddOpenApiDocument();
+        services.AddOpenApiDocument(configure =>
+        {
+            configure.Title = ApiTitle;
+            configure.Version = ApiVersion;
+            configure.Description = ApiDescription;
+        
+            configure.AddSecurity("JWT", [], new OpenApiSecurityScheme
+            {
+                Type = OpenApiSecuritySchemeType.ApiKey,
+                Scheme = "Bearer ",
+                Name = "Authorization",
+                In = OpenApiSecurityApiKeyLocation.Header,
+                Description = "Type into the textbox: Bearer {your JWT token}."
+            });
+        
+            configure.OperationProcessors.Add(new AspNetCoreOperationSecurityScopeProcessor("JWT"));
+        });
+
+        services
+            .AddAuthentication(options =>
+            {
+                options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
+                options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
+                options.DefaultScheme = JwtBearerDefaults.AuthenticationScheme;
+            })
+            .AddScheme<JwtBearerOptions, JwtAuthenticationHandler>(JwtBearerDefaults.AuthenticationScheme,
+                options => { }
+            );
+
+        services.AddAuthorization(options =>
+        {
+            options.FallbackPolicy = new AuthorizationPolicyBuilder()
+                .RequireAssertion(context =>
+                {
+                    if (context.Resource is not HttpContext httpContext) return false;
+            
+                    // Tillad OPTIONS for CORS
+                    if (string.Equals(httpContext.Request.Method, "OPTIONS", StringComparison.OrdinalIgnoreCase))
+                        return true;
+
+                    // Tillad swagger og root
+                    if (httpContext.Request.Path.StartsWithSegments("/swagger") ||
+                        httpContext.Request.Path.StartsWithSegments("/swagger-ui") ||
+                        httpContext.Request.Path.Equals("/"))
+                        return true;
+
+                    // Kræv autentificering for alt andet
+                    return context.User.Identity?.IsAuthenticated ?? false;
+                })
+                .Build();
+            
+            options.AddPolicy("admin", policy => policy.RequireRole("admin"));
+            options.AddPolicy("user", policy => policy.RequireRole("user"));
+        });
+        
+        services.AddRouting(options =>
+        {
+            options.LowercaseUrls = true;
+        });
+        
         return services;
     }
 
     public static WebApplication ConfigureHttpApi(this WebApplication app, int port)
     {
         app.UseOpenApi();
-        app.UseSwaggerUi();
+        
+        app.UseSwaggerUi(settings =>
+        {
+            settings.DocumentTitle = ApiTitle;
+            settings.DocExpansion = "list";
+        });
+        
+        app.UseAuthentication();
+        app.UseAuthorization();
+        
         app.MapControllers();
         app.Urls.Add($"http://0.0.0.0:{port}");
         return app;

--- a/server/Api.Http/Auth/JwtAuthenticationHandler.cs
+++ b/server/Api.Http/Auth/JwtAuthenticationHandler.cs
@@ -1,0 +1,56 @@
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+using Application.Interfaces.Auth;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using IAuthenticationService = Application.Interfaces.Auth.IAuthenticationService;
+
+namespace Api.Http.Auth;
+
+public class JwtAuthenticationHandler : AuthenticationHandler<JwtBearerOptions>
+{
+    private readonly IAuthenticationService _authenticationService;
+
+    public JwtAuthenticationHandler(
+        IOptionsMonitor<JwtBearerOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder,
+        IAuthenticationService authenticationService) 
+        : base(options, logger, encoder) 
+    {
+        _authenticationService = authenticationService;
+    }
+
+    protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue("Authorization", out var authHeader)) return AuthenticateResult.NoResult();
+
+        var headerValue = authHeader.ToString();
+        if (!headerValue.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase))
+        {
+            return AuthenticateResult.NoResult();
+        }
+
+        var token = headerValue["Bearer ".Length..].Trim();
+        var authResult = await _authenticationService.ValidateTokenAsync(token);
+        if (!authResult.IsAuthenticated) return AuthenticateResult.Fail("Invalid token");
+
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.NameIdentifier, authResult.UserId!)
+        };
+
+        foreach (var role in authResult.Roles)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+        }
+
+        var identity = new ClaimsIdentity(claims, Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, Scheme.Name);
+
+        return AuthenticateResult.Success(ticket);
+    }
+}

--- a/server/Api.Http/Controllers/TestAuthController.cs
+++ b/server/Api.Http/Controllers/TestAuthController.cs
@@ -1,0 +1,24 @@
+using Application.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Http.Controllers;
+
+[Route("api/[controller]")]
+[ApiController]
+public class TestAuthController(IJwtService jwtService) : ControllerBase
+{
+    [AllowAnonymous]
+    [HttpGet("")]
+    public IActionResult GetUser()
+    {
+        return Ok(jwtService.Generate("kakao", "kakao@mælk.dk", "user"));
+    }
+
+    [Authorize(Roles = "user")]
+    [HttpGet("/hej")]
+    public IActionResult DeleteUser()
+    {
+        return Ok();
+    }
+}

--- a/server/Api.Http/packages.lock.json
+++ b/server/Api.Http/packages.lock.json
@@ -2,6 +2,15 @@
   "version": 1,
   "dependencies": {
     "net8.0": {
+      "Microsoft.AspNetCore.Authentication.JwtBearer": {
+        "type": "Direct",
+        "requested": "[8.0.15, )",
+        "resolved": "8.0.15",
+        "contentHash": "41DQAWCOIDS9ZzW6hWCShRiVrBLvz2QqR+i0VhMa4JHuQLNW2axfiWgEbB8jYt8try1ez2Q+z1PfF3vbl+B9gA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "7.1.2"
+        }
+      },
       "NSwag.AspNetCore": {
         "type": "Direct",
         "requested": "[14.3.0, )",
@@ -79,6 +88,53 @@
         "type": "Transitive",
         "resolved": "9.0.3",
         "contentHash": "yCCJHvBcRyqapMSNzP+kTc57Eaavq2cr5Tmuil6/XVnipQf5xmskxakSQ1enU6S4+fNg3sJ27WcInV64q24JsA=="
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "7.1.2",
+        "contentHash": "33eTIA2uO/L9utJjZWbKsMSVsQf7F8vtd6q5mQX7ZJzNvCpci5fleD6AeANGlbbb7WX7XKxq9+Dkb5e3GNDrmQ=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "7.1.2",
+        "contentHash": "cloLGeZolXbCJhJBc5OC05uhrdhdPL6MWHuVUnkkUvPDeK7HkwThBaLZ1XjBQVk9YhxXE2OvHXnKi0PLleXxDg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "7.1.2"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "7.1.2",
+        "contentHash": "YCxBt2EeJP8fcXk9desChkWI+0vFqFLvBwrz5hBMsoh0KJE6BC66DnzkdzkJNqMltLromc52dkdT206jJ38cTw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "7.1.2"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "7.1.2",
+        "contentHash": "SydLwMRFx6EHPWJ+N6+MVaoArN1Htt92b935O3RUWPY1yUF63zEjvd3lBu79eWdZUwedP8TN2I5V9T3nackvIQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "7.1.2",
+          "Microsoft.IdentityModel.Tokens": "7.1.2"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "7.1.2",
+        "contentHash": "6lHQoLXhnMQ42mGrfDkzbIOR3rzKM1W1tgTeMPLgLCqwwGw0d96xFi/UiX/fYsu7d6cD5MJiL3+4HuI8VU+sVQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "7.1.2",
+          "System.IdentityModel.Tokens.Jwt": "7.1.2"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "7.1.2",
+        "contentHash": "oICJMqr3aNEDZOwnH5SK49bR6Z4aX0zEAnOLuhloumOSuqnNq+GWBdQyrgILnlcT5xj09xKCP/7Y7gJYB+ls/g==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "7.1.2"
+        }
       },
       "Namotion.Reflection": {
         "type": "Transitive",
@@ -168,6 +224,15 @@
         "type": "Transitive",
         "resolved": "9.0.3",
         "contentHash": "cBA+28xDW33tSiGht/H8xvr8lnaCrgJ7EdO348AfSGsX4PPJUOULKxny/cc9DVNGExaCrtqagsnm5M2mkWIZ+g=="
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "7.1.2",
+        "contentHash": "Thhbe1peAmtSBFaV/ohtykXiZSOkx59Da44hvtWfIMFofDA3M3LaVyjstACf2rKGn4dEDR2cUpRAZ0Xs/zB+7Q==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "7.1.2",
+          "Microsoft.IdentityModel.Tokens": "7.1.2"
+        }
       },
       "YamlDotNet": {
         "type": "Transitive",

--- a/server/Application/Interfaces/Auth/IAuthenticationService.cs
+++ b/server/Application/Interfaces/Auth/IAuthenticationService.cs
@@ -1,0 +1,8 @@
+using Application.Models;
+
+namespace Application.Interfaces.Auth;
+
+public interface IAuthenticationService
+{
+    Task<AuthenticationResult> ValidateTokenAsync(string token);
+}

--- a/server/Application/Models/AuthenticationResult.cs
+++ b/server/Application/Models/AuthenticationResult.cs
@@ -1,0 +1,23 @@
+namespace Application.Models;
+
+public class AuthenticationResult
+{
+    public bool IsAuthenticated { get; }
+    public string? UserId { get; }
+    public IReadOnlyList<string> Roles { get; }
+
+    public AuthenticationResult(bool isAuthenticated, string? userId = null, IEnumerable<string>? roles = null)
+    {
+        IsAuthenticated = isAuthenticated;
+        UserId = userId;
+        Roles = roles?.ToArray() ?? [];
+    }
+
+    public bool HasRole(string role) => Roles.Contains(role, StringComparer.OrdinalIgnoreCase);
+
+    public bool HasAnyRole(IEnumerable<string> requiredRoles)
+    {
+        var roleArray = requiredRoles as string[] ?? requiredRoles.ToArray();
+        return roleArray.Length == 0 || roleArray.Any(HasRole);
+    }
+}

--- a/server/Infrastructure.Auth/Extensions.cs
+++ b/server/Infrastructure.Auth/Extensions.cs
@@ -1,0 +1,13 @@
+using Application.Interfaces.Auth;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Infrastructure.Auth;
+
+public static class AuthExtensions
+{
+    public static IServiceCollection AddAuthInfrastructure(this IServiceCollection services)
+    {
+        services.AddScoped<IAuthenticationService, JwtAuthenticationService>();
+        return services;
+    }
+}

--- a/server/Infrastructure.Auth/JwtAuthenticationService.cs
+++ b/server/Infrastructure.Auth/JwtAuthenticationService.cs
@@ -1,0 +1,22 @@
+using Application.Interfaces.Auth;
+using Application.Models;
+using Application.Services;
+
+namespace Infrastructure.Auth;
+
+public class JwtAuthenticationService : IAuthenticationService
+{
+    private readonly IJwtService _jwtService;
+    
+    public JwtAuthenticationService(IJwtService jwtService)
+    {
+        _jwtService = jwtService;
+    }
+    
+    public Task<AuthenticationResult> ValidateTokenAsync(string token)
+    {
+        return Task.FromResult(_jwtService.TryValidate(token, out var claims) 
+            ? new AuthenticationResult(true, claims.Sub, [claims.Role])
+            : new AuthenticationResult(false));
+    }
+}

--- a/server/Startup/Program.cs
+++ b/server/Startup/Program.cs
@@ -1,5 +1,6 @@
 using Api.Http;
 using Application;
+using Infrastructure.Auth;
 using Infrastructure.Communication;
 using Infrastructure.Data;
 using Microsoft.Extensions.Options;
@@ -16,6 +17,7 @@ public static class Program
             .ValidateOnStart();
         services.AddCommunicationInfrastructure();
         services.AddDataInfrastructure();
+        services.AddAuthInfrastructure();
         services.AddHttpApi();
         services.AddApplicationServices();
     }

--- a/server/Startup/packages.lock.json
+++ b/server/Startup/packages.lock.json
@@ -41,6 +41,14 @@
           "MimeKit": "2.10.1"
         }
       },
+      "Microsoft.AspNetCore.Authentication.JwtBearer": {
+        "type": "Transitive",
+        "resolved": "8.0.15",
+        "contentHash": "41DQAWCOIDS9ZzW6hWCShRiVrBLvz2QqR+i0VhMa4JHuQLNW2axfiWgEbB8jYt8try1ez2Q+z1PfF3vbl+B9gA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "7.1.2"
+        }
+      },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
         "resolved": "9.0.3",
@@ -167,6 +175,53 @@
         "type": "Transitive",
         "resolved": "9.0.3",
         "contentHash": "yCCJHvBcRyqapMSNzP+kTc57Eaavq2cr5Tmuil6/XVnipQf5xmskxakSQ1enU6S4+fNg3sJ27WcInV64q24JsA=="
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "7.1.2",
+        "contentHash": "33eTIA2uO/L9utJjZWbKsMSVsQf7F8vtd6q5mQX7ZJzNvCpci5fleD6AeANGlbbb7WX7XKxq9+Dkb5e3GNDrmQ=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "7.1.2",
+        "contentHash": "cloLGeZolXbCJhJBc5OC05uhrdhdPL6MWHuVUnkkUvPDeK7HkwThBaLZ1XjBQVk9YhxXE2OvHXnKi0PLleXxDg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "7.1.2"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "7.1.2",
+        "contentHash": "YCxBt2EeJP8fcXk9desChkWI+0vFqFLvBwrz5hBMsoh0KJE6BC66DnzkdzkJNqMltLromc52dkdT206jJ38cTw==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "7.1.2"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "7.1.2",
+        "contentHash": "SydLwMRFx6EHPWJ+N6+MVaoArN1Htt92b935O3RUWPY1yUF63zEjvd3lBu79eWdZUwedP8TN2I5V9T3nackvIQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "7.1.2",
+          "Microsoft.IdentityModel.Tokens": "7.1.2"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "7.1.2",
+        "contentHash": "6lHQoLXhnMQ42mGrfDkzbIOR3rzKM1W1tgTeMPLgLCqwwGw0d96xFi/UiX/fYsu7d6cD5MJiL3+4HuI8VU+sVQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "7.1.2",
+          "System.IdentityModel.Tokens.Jwt": "7.1.2"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "7.1.2",
+        "contentHash": "oICJMqr3aNEDZOwnH5SK49bR6Z4aX0zEAnOLuhloumOSuqnNq+GWBdQyrgILnlcT5xj09xKCP/7Y7gJYB+ls/g==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "7.1.2"
+        }
       },
       "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
@@ -316,6 +371,15 @@
         "resolved": "9.0.3",
         "contentHash": "cBA+28xDW33tSiGht/H8xvr8lnaCrgJ7EdO348AfSGsX4PPJUOULKxny/cc9DVNGExaCrtqagsnm5M2mkWIZ+g=="
       },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "7.1.2",
+        "contentHash": "Thhbe1peAmtSBFaV/ohtykXiZSOkx59Da44hvtWfIMFofDA3M3LaVyjstACf2rKGn4dEDR2cUpRAZ0Xs/zB+7Q==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "7.1.2",
+          "Microsoft.IdentityModel.Tokens": "7.1.2"
+        }
+      },
       "System.Reflection.TypeExtensions": {
         "type": "Transitive",
         "resolved": "4.4.0",
@@ -351,6 +415,7 @@
         "type": "Project",
         "dependencies": {
           "Application": "[1.0.0, )",
+          "Microsoft.AspNetCore.Authentication.JwtBearer": "[8.0.15, )",
           "NSwag.AspNetCore": "[14.3.0, )"
         }
       },


### PR DESCRIPTION
- Tilføjet IAuthenticationService interface i Applications
- Tiløjet implementation af ovenstående interface JwtAuthentication- Service i Infrastructure.Auth, som gør brug af IJwtService.TryValidate
- Tilføjet AuthenticationResult model til standardisered Authentication resultat.
- Implementeret JwtAuthenticationHandler i Api.Http, der bruger IAuthenticationService til at validere token og oprette ClaimsPrincipal
- Konfigureret ASP.NET Core i ApiStartup for Api.Http til at bruge den ovenstående handler via AddScheme.
- Blacklistet alle endpoints per default.

Tags: autentificering, autorisering, auth, jwt, http, sikkerhed